### PR TITLE
reading config from config.plugins.jshint

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -12,7 +12,7 @@ module.exports = class JSHintLinter
   constructor: (@config) ->
     cfg = @config?.plugins?.jshint ? @config?.jshint ? {}
     
-    if cfg is @config?.jshint?
+    if @config?.jshint
       console.warn "Warning: config.jshint is deprecated, move it to config.plugins.jshint"
 
     @options = cfg.options


### PR DESCRIPTION
Left it backward compatible and threw in a deprecation warning
